### PR TITLE
New selected emoji will always appear as first in recent.

### DIFF
--- a/Source/Classes/Helpers/RecentEmojisManager.swift
+++ b/Source/Classes/Helpers/RecentEmojisManager.swift
@@ -20,22 +20,21 @@ final internal class RecentEmojisManager {
     // MARK: - Public functions
     
     internal func add(emoji: Emoji, selectedEmoji: String) -> Bool {
-        guard maxCountOfCenetEmojis > 0 else {
-            return false
-        }
-        
         var emojis = recentEmojis()
         
-        if emojis.contains(where: { $0.selectedEmoji == selectedEmoji }) {
-            return false
-        }
-        
-        if emojis.count >= maxCountOfCenetEmojis {
-            emojis.removeLast()
-        }
-        
         emoji.selectedEmoji = selectedEmoji
+        
+        let hasEmoji = emojis.firstIndex(of: emoji)// 'contains' is slow
+        
+        if let index = hasEmoji {
+            emojis.remove(at: index)
+        }// now recent emoji will always appear as first
+        
         emojis.insert(emoji, at: 0)
+        
+        if emojis.count > maxCountOfCenetEmojis {
+            emojis.removeLast(emojis.count-maxCountOfCenetEmojis)
+        }
         
         if let data = try? JSONEncoder().encode(emojis) {
             UserDefaults.standard.set(data, forKey: RecentEmojisKey)

--- a/Source/Classes/Models/Emoji.swift
+++ b/Source/Classes/Models/Emoji.swift
@@ -43,3 +43,8 @@ public class Emoji: Codable {
     
 }
 
+extension Emoji:Equatable {
+    public static func == (lhs: Emoji, rhs: Emoji) -> Bool {
+        return lhs.selectedEmoji == rhs.selectedEmoji
+    }
+}


### PR DESCRIPTION
Since system emoji keyboard's recent sorted by tap frequency, I have changed ISEmojiView's recent emoji rule that always put new used emoji on first.

This behavior prevented the freqently used emoji disappear from the recent section. 🙂