### PR TITLE
Restore iOS 12 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,6 @@ let package = Package(
             path: "Sources",
             resources: [
                 .process("ISEmojiView/Assets"),
-                .copy("ISEmojiView/Assets/Views/*.xib")
             ]
             ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "ISEmojiView",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v12)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/ISEmojiView/EmojiView_SwiftUI.swift
+++ b/Sources/ISEmojiView/EmojiView_SwiftUI.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import UIKit
 
+@available(iOS 13.0, *)
 public struct EmojiView_SwiftUI: UIViewRepresentable {
     public typealias UIViewType = EmojiView
     
@@ -73,6 +74,7 @@ public struct EmojiView_SwiftUI: UIViewRepresentable {
     }
 }
 
+@available(iOS 13.0, *)
 struct EmojiView_SwiftUI_Previews: PreviewProvider {
     static var previews: some View {
         EmojiView_SwiftUI()


### PR DESCRIPTION
First of all, thanks for this awesome library!

The 0.3.0 release, which is available via SPM, increased the deployment target to iOS 13, which popped up when I was migrating an older project to SPM – still targeting 12.

I've found that by adding `@available` annotations to the SwiftUI classes, everything else is still working fine on the older OS, so here's a PR that changes just that.