### PR TITLE
Fix countOfRecentsEmojis not work

### DIFF
--- a/Sources/ISEmojiView/Classes/Helpers/RecentEmojisManager.swift
+++ b/Sources/ISEmojiView/Classes/Helpers/RecentEmojisManager.swift
@@ -18,7 +18,13 @@ final public class RecentEmojisManager {
     
     // MARK: - Public functions
     
-    public func add(emoji: Emoji, selectedEmoji: String) -> Bool {
+    public func add(emoji: Emoji, selectedEmoji: String, maxCount: Int) -> Bool {
+        if (maxCount == 0) {
+            UserDefaults.standard.removeObject(forKey: recentEmojisKey)
+            UserDefaults.standard.removeObject(forKey: recentEmojisFreqStorageKey)
+            return false
+        }
+        
         var emojis = recentEmojis()
         var freqData = recentEmojisFreqData()
         
@@ -36,13 +42,13 @@ final public class RecentEmojisManager {
                 return true
         }
 
-        if emojis.count > MaxCountOfRecentsEmojis {
-            emojis.removeLast(emojis.count-MaxCountOfRecentsEmojis)
+        if emojis.count > maxCount {
+            emojis.removeLast(emojis.count-maxCount)
         }
         
-        if emojis.count > 0 && emojis.count == MaxCountOfRecentsEmojis {
+        if emojis.count > 0 && emojis.count == maxCount {
             let toRemove = emojis.removeLast()
-            let newIndex = MaxCountOfRecentsEmojis/3
+            let newIndex = maxCount/3
             let oldOne = emojis[newIndex].selectedEmoji ?? ""
             emojis.insert(emoji, at: newIndex)
             freqData[selectedEmoji] = (freqData[oldOne] ?? 0) + 1

--- a/Sources/ISEmojiView/Classes/Views/EmojiView/EmojiView.swift
+++ b/Sources/ISEmojiView/Classes/Views/EmojiView/EmojiView.swift
@@ -109,6 +109,7 @@ final public class EmojiView: UIView {
         
         bottomType = keyboardSettings.bottomType
         emojis = keyboardSettings.customEmojis ?? EmojiLoader.emojiCategories()
+        countOfRecentsEmojis = keyboardSettings.countOfRecentsEmojis
         
         if keyboardSettings.countOfRecentsEmojis > 0 {
             emojis.insert(EmojiLoader.recentEmojiCategory(), at: 0)
@@ -159,7 +160,7 @@ final public class EmojiView: UIView {
 extension EmojiView: EmojiCollectionViewDelegate {
     
     func emojiViewDidSelectEmoji(emojiView: EmojiCollectionView, emoji: Emoji, selectedEmoji: String) {
-        if RecentEmojisManager.sharedInstance.add(emoji: emoji, selectedEmoji: selectedEmoji),(keyboardSettings?.updateRecentEmojiImmediately) ?? true  {
+        if RecentEmojisManager.sharedInstance.add(emoji: emoji, selectedEmoji: selectedEmoji, maxCount: countOfRecentsEmojis),(keyboardSettings?.updateRecentEmojiImmediately) ?? true  {
             emojiCollectionView?.updateRecentsEmojis(RecentEmojisManager.sharedInstance.recentEmojis())
         }
         


### PR DESCRIPTION
Stumbled upon countOfRecentsEmojis config not working, fixed it.

```swift
/// The max number of recent emojis, if set 0, nothing will be shown. Default is 50.
public var countOfRecentsEmojis: Int = MaxCountOfRecentsEmojis
```