### PR TITLE
Emoji clean up

### DIFF
--- a/Sources/ISEmojiView/Assets/ISEmojiList.plist
+++ b/Sources/ISEmojiView/Assets/ISEmojiList.plist
@@ -69,7 +69,6 @@
 			<string>😨</string>
 			<string>😩</string>
 			<string>🤯</string>
-			<string>🧠</string>
 			<string>🫠</string>
 			<string>🫡</string>
 			<string>🫣</string>


### PR DESCRIPTION
chore: removed a redundant emoji (🧠).